### PR TITLE
Fix for reading of object_box_orientation_angle

### DIFF
--- a/src/ibeo_core.cpp
+++ b/src/ibeo_core.cpp
@@ -410,8 +410,8 @@ void Object2280::parse(uint8_t *in)
   object_box_center.parse(&in[40], BE);
   object_box_center_sigma.parse(&in[48], BE);
   object_box_size.parse(&in[56], BE);
-  object_box_orientation_angle = read_le<float>(in, 4, 72);
-  object_box_orientation_angle_sigma = read_le<float>(in, 4, 76);
+  object_box_orientation_angle = read_be<float>(in, 4, 72);
+  object_box_orientation_angle_sigma = read_be<float>(in, 4, 76);
   relative_velocity.parse(&in[80], BE);
   relative_velocity_sigma.parse(&in[88], BE);
   absolute_velocity.parse(&in[96], BE);


### PR DESCRIPTION
Byte order for object bounding box orientation angle changed from little-endian to big-endian. According to the document "Interface Specification for ibeo LUX, ibeo LUX systems and ibeo Evaluation Suite", version 1.48 from 30.05.2017 there is big-endian byte order for all fields in Object2280. If i am using original code orientation of objects changes abruptly. With that fix it seems to work correct.