### PR TITLE
Bigger Point Clouds enabled

### DIFF
--- a/include/ibeo_core/ibeo_core.h
+++ b/include/ibeo_core/ibeo_core.h
@@ -343,7 +343,7 @@ public:
 
   void parse(
     const std::vector<uint8_t>& in,
-    const uint16_t& offset);
+    const uint32_t& offset);
 };
 
 class ScanPoint2204
@@ -363,7 +363,7 @@ public:
 
   void parse(
     const std::vector<uint8_t>& in,
-    const uint16_t& offset);
+    const uint32_t& offset);
 };
 
 class ScanPoint2205
@@ -384,7 +384,7 @@ public:
 
   void parse(
     const std::vector<uint8_t>& in,
-    const uint16_t& offset);
+    const uint32_t& offset);
 };
 
 class ScanPoint2208
@@ -402,7 +402,7 @@ public:
 
   void parse(
     const std::vector<uint8_t>& in,
-    const uint16_t& offset);
+    const uint32_t& offset);
 };
 
 struct IbeoObject

--- a/src/ibeo_core.cpp
+++ b/src/ibeo_core.cpp
@@ -218,7 +218,7 @@ void TrackedProperties::parse(const std::vector<uint8_t>& in, const uint16_t& of
   }
 }
 
-void ScanPoint2202::parse(const std::vector<uint8_t>& in, const uint16_t& offset)
+void ScanPoint2202::parse(const std::vector<uint8_t>& in, const uint32_t& offset)
 {
   uint8_t layer_and_offset = read_le<uint8_t>(in, offset);
   std::cout << std::hex;
@@ -234,7 +234,7 @@ void ScanPoint2202::parse(const std::vector<uint8_t>& in, const uint16_t& offset
   echo_pulse_width = read_le<uint16_t>(in, offset + 6);
 }
 
-void ScanPoint2204::parse(const std::vector<uint8_t>& in, const uint16_t& offset)
+void ScanPoint2204::parse(const std::vector<uint8_t>& in, const uint32_t& offset)
 {
   x_position = read_be<float>(in, offset + 0);
   y_position = read_be<float>(in, offset + 4);
@@ -252,7 +252,7 @@ void ScanPoint2204::parse(const std::vector<uint8_t>& in, const uint16_t& offset
   precipitation = ((flags & 0x0004) > 0);
 }
 
-void ScanPoint2205::parse(const std::vector<uint8_t>& in, const uint16_t& offset)
+void ScanPoint2205::parse(const std::vector<uint8_t>& in, const uint32_t& offset)
 {
   x_position = read_be<float>(in, offset);
   y_position = read_be<float>(in, offset + 4);
@@ -269,7 +269,7 @@ void ScanPoint2205::parse(const std::vector<uint8_t>& in, const uint16_t& offset
   transparent = ((flags & 0x1000) > 12);
 }
 
-void ScanPoint2208::parse(const std::vector<uint8_t>& in, const uint16_t& offset)
+void ScanPoint2208::parse(const std::vector<uint8_t>& in, const uint32_t& offset)
 {
   echo = (read_be<uint8_t>(in, offset) & 0x0C);
   layer = read_be<uint8_t>(in, offset + 1);  // & 0x03; < should be whole byte, but this gives unexpected results.


### PR DESCRIPTION
The current type `uint16` does not allow more than 2323 Points to be parsed (with 3 sensors. with 6, even less are enabled due to increase of sensor_info header).

as the second image shows, points will not be parsed correctly after point 2323. 

24 + (3*148) + (2324 * 28) = 65.540
24 + (3*148) + (2323 * 28) = 65.512
2^16 = 65.536

![image](https://user-images.githubusercontent.com/64705964/128331413-bcfc4d1a-2639-4084-8b3c-bd1bbf9b9925.png)

![image](https://user-images.githubusercontent.com/64705964/128331721-24f2130c-b658-47e7-ad32-1071b5206e20.png)


I tested this fix live with six sensors and the ScanPoint 2208 message.
The other types I just increased for future problems.

should be changed for type 2209 in https://github.com/astuff/ibeo_core/pull/15 as well.